### PR TITLE
修复可能处理半开/半关状态的连接问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+
+COPY http2tcp /
+ENTRYPOINT ["/http2tcp"]
+

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"io"
+	"os"
+	"sync"
+)
+
+type WriteCloser interface {
+	CloseWrite() error
+}
+
+type OnceCloser struct {
+	io.Closer
+	once sync.Once
+}
+
+func (c *OnceCloser) Close() (err error) {
+	c.once.Do(func() {
+		err = c.Closer.Close()
+	})
+	return
+}
+
+type StdReadWriteCloser struct {
+	io.ReadCloser
+	io.WriteCloser
+
+	closed      bool
+	writeClosed bool
+	mu          sync.Mutex
+}
+
+func NewStdReadWriteCloser() *StdReadWriteCloser {
+	return &StdReadWriteCloser{
+		ReadCloser:  os.Stdin,
+		WriteCloser: os.Stdout,
+	}
+}
+
+func (c *StdReadWriteCloser) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.closed {
+		return os.ErrInvalid
+	}
+
+	c.closed = true
+
+	var (
+		err1 error
+		err2 error
+	)
+
+	err1 = c.ReadCloser.Close()
+	if !c.writeClosed {
+		err2 = c.WriteCloser.Close()
+		c.writeClosed = true
+	}
+
+	if err1 != nil {
+		return err1
+	}
+	if err2 != nil {
+		return err2
+	}
+
+	return nil
+}
+
+func (c *StdReadWriteCloser) CloseWrite() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.closed || c.writeClosed {
+		return os.ErrInvalid
+	}
+	c.writeClosed = true
+	return c.WriteCloser.Close()
+}


### PR DESCRIPTION
@xxxsen 帮忙看看。

另外，`io.Copy(remote, local)`  报错返回的时候，是没法确定是 `remote` 出错了还是 `local` 出错了。所以直接简单粗暴地 `Close` 最省事？